### PR TITLE
Corrección dobles registros y eliminaciones nulas

### DIFF
--- a/ClientApp/src/app/horario/horario.component.ts
+++ b/ClientApp/src/app/horario/horario.component.ts
@@ -141,8 +141,8 @@ export class HorarioComponent implements OnInit {
   GuardarCambios() {
 
     
-    this.GuardarHorario();
     this.EliminarReserva();
+    this.GuardarHorario();
     alert("Cambios guardados exitosamente");
     
   }
@@ -168,6 +168,7 @@ export class HorarioComponent implements OnInit {
           }
         )
       this.tamaño--;
+      this.cont+=this.nuevas;
 
 
     }
@@ -180,6 +181,7 @@ export class HorarioComponent implements OnInit {
     this.ListaReservasOriginal.forEach(element => {
       const index = this.scheduleData.map(e => e.Id).indexOf(element.id)
       if(index==-1){
+        this.cont-=1;
         this.serviceLaboratorio.DeleteReserva(element.id).subscribe(
           )
           data=>{

--- a/ClientApp/src/app/reserva/reserva.component.ts
+++ b/ClientApp/src/app/reserva/reserva.component.ts
@@ -130,7 +130,7 @@ export class ReservaComponent implements OnInit {
           }
         )
       this.tamaño--;
-
+      this.cont+=this.nuevas;
 
     }
 
@@ -166,8 +166,8 @@ export class ReservaComponent implements OnInit {
   GuardarCambios() {
 
     
-    this.GuardarReserva();
     this.EliminarReserva();
+    this.GuardarReserva();
     alert("Cambios guardados exitosamente");
     
   }
@@ -179,6 +179,8 @@ export class ReservaComponent implements OnInit {
     this.ListaReservasOriginal.forEach(element => {
       const index = this.scheduleData.map(e => e.Id).indexOf(element.id)
       if(index==-1){
+        
+      this.cont-=1;
         this.serviceLaboratorio.DeleteReserva(element.id).subscribe(
           )
           data=>{


### PR DESCRIPTION
Se corrige:
- Se guardaba múltiples veces las reservas al hacer clic múltiple veces
- No se guardaban los nuevos registros si se eliminaba algunos previamente